### PR TITLE
Added captions to Media model objects

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -47,7 +47,11 @@ class Media(ApiModel):
 
         if entry['location']:
             new_media.location = Location.object_from_dictionary(entry['location'])
-
+		
+        new_media.caption = None
+        if entry['caption']:
+            new_media.caption = Comment.object_from_dictionary( entry['caption'] )
+		
         new_media.link = entry['link']
 
         return new_media


### PR DESCRIPTION
I noticed that captions for Media objects were missing in the model, despite being part of the data returned by the API. This is a very simple patch to add them to the model.  I used a Comment object since a Caption appears to be the same thing.
