### PR TITLE
Disable SSL validation.

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -90,7 +90,7 @@ class OAuth2AuthExchangeRequest(object):
         return self._url_for_authorize(scope = scope)
 
     def get_authorize_login_url(self, scope=None):
-        http_object = Http()
+        http_object = Http(disable_ssl_certificate_validation=True)
 
         url = self._url_for_authorize(scope = scope)
         response, content = http_object.request(url)
@@ -101,7 +101,7 @@ class OAuth2AuthExchangeRequest(object):
 
     def exchange_for_access_token(self, code=None, username=None, password=None, scope=None, user_id=None):
         data = self._data_for_exchange(code, username, password, scope = scope, user_id = user_id)
-        http_object = Http()
+        http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
         response, content = http_object.request(url, method="POST", body=data)
         parsed_content = simplejson.loads(content)
@@ -204,5 +204,5 @@ class OAuth2Request(object):
     def make_request(self, url, method="GET", body=None, headers={}):
         if not 'User-Agent' in headers:
             headers.update({"User-Agent":"%s Python Client" % self.api.api_name})
-        http_obj = Http()
+        http_obj = Http(disable_ssl_certificate_validation=True)
         return http_obj.request(url, method, body=body, headers=headers)


### PR DESCRIPTION
The Instagram API is signed with a GeoTrust Global CA. Unfortunately
this CA root certificate is not part of the default cacert.txt file
that ships with httplib2.

Rather than ship the certificate file, let's just ignore the SSL
validation issue.

Once the upstream bug is fixed,
 http://code.google.com/p/httplib2/issues/detail?id=156
we can revert this change.
