### PR TITLE
As well as returning the access_token, return who it is associated to

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -107,7 +107,7 @@ class OAuth2AuthExchangeRequest(object):
         parsed_content = simplejson.loads(content)
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("message", ""))
-        return parsed_content['access_token']
+        return parsed_content['access_token'], parsed_content['user']
 
 
 class OAuth2Request(object):


### PR DESCRIPTION
Returning the access_token is useful, but even more important is knowing
which user has granted us access.
