### PR TITLE
Changed message to error_message

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -108,7 +108,7 @@ class OAuth2AuthExchangeRequest(object):
         response, content = http_object.request(url, method="POST", body=data)
         parsed_content = simplejson.loads(content)
         if int(response['status']) != 200:
-            raise OAuth2AuthExchangeError(parsed_content.get("message", ""))
+            raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))
         return parsed_content['access_token'], parsed_content['user']
 
 


### PR DESCRIPTION
That's what I see in the API responses.
Example JSON:

{"code": 400, "error_type": "OAuthException", "error_message": "Redirect URI doesn't match original redirect URI"}
