### PR TITLE
Support for foursquare_v2_id parameter in location_search method

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Locations: http://instagr.am/developer/endpoints/locations/
 
     api.location(location_id)
     api.location_recent_media(count, max_id, location_id)*
-    api.location_search(q, count, lat, lng, foursquare_id)
+    api.location_search(q, count, lat, lng, foursquare_id, foursquare_v2_id)
     
 Geographies: http://instagr.am/developer/endpoints/geographies/
 

--- a/instagram/client.py
+++ b/instagram/client.py
@@ -128,7 +128,7 @@ class InstagramAPI(oauth2.OAuth2API):
 
     location_search = bind_method(
                 path="/locations/search",
-                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng', 'foursquare_id'],
+                accepts_parameters=SEARCH_ACCEPT_PARAMETERS + ['lat', 'lng', 'foursquare_id', 'foursquare_v2_id'],
                 root_class=Location)
 
     location = bind_method(


### PR DESCRIPTION
Just a simple pull request so a foursquare_v2_id can be passed to location_search per the Instagram API documentation for the /locations/search endpoint.
