### PR TITLE
Import simplejson with json_import

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -1,4 +1,4 @@
-import simplejson
+from json_import import simplejson
 import urllib
 from httplib2 import Http
 import mimetypes


### PR DESCRIPTION
While using python-instagram with GAE, oauth2.py fails to load simplejson.

simplejson should always be loaded with json_import
