### PR TITLE
Adding an optional status_code to InstagramClientError

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -12,11 +12,15 @@ def encode_string(value):
 
 
 class InstagramClientError(Exception):
-    def __init__(self, error_message):
+    def __init__(self, error_message, status_code=None):
+        self.status_code = status_code
         self.error_message = error_message
 
     def __str__(self):
-        return self.error_message
+        if self.status_code:
+            return "(%s) %s" % (self.status_code, self.error_message)
+        else:
+            return self.error_message
 
 
 class InstagramAPIError(Exception):
@@ -97,7 +101,7 @@ def bind_method(**config):
             try:
                 content_obj = simplejson.loads(content)
             except ValueError:
-                raise InstagramClientError('Unable to parse response, not valid JSON.')
+                raise InstagramClientError('Unable to parse response, not valid JSON.', status_code=response['status'])
 
             # Handle OAuthRateLimitExceeded from Instagram's Nginx which uses different format to documented api responses
             if not content_obj.has_key('meta'):


### PR DESCRIPTION
Fairly regularly, the Instagram API returns HTTP 504s and/or 502s. This raises an `InstagramClientError` with the message “Unable to parse response, not valid JSON.” To be able to catch and handle only 502 and 504 errors, `InstagramClientError` needs to pass along the `status_code` of the response.

For the future, I think the cleaner way to handle these errors would be to use an `InstagramAPIError` instead of an `InstagramClientError` for handling invalid JSON. bind.py:100 would then look like this:

```
raise InstagramAPIError(response['status'], "Invalid JSON", "Unable to parse response, not valid JSON.")
```

However, this has the potential to break compatibility with old versions if people are expecting an `InstagramClientError` for invalid JSON. This provides an interim solution without breaking compatibility.
