### PR TITLE
Support the signed header.

### DIFF
--- a/instagram/client.py
+++ b/instagram/client.py
@@ -46,18 +46,21 @@ class InstagramAPI(oauth2.OAuth2API):
     like_media = bind_method(
                 path="/media/{media_id}/likes",
                 method="POST",
+                signature=True,
                 accepts_parameters=['media_id'],
                 response_type="empty")
 
     unlike_media = bind_method(
                 path="/media/{media_id}/likes",
                 method="DELETE",
+                signature=True,
                 accepts_parameters=['media_id'],
                 response_type="empty")
 
     create_media_comment = bind_method(
                 path="/media/{media_id}/comments",
                 method="POST",
+                signature=True,
                 accepts_parameters=['media_id', 'text'],
                 response_type="empty",
                 root_class=Comment)
@@ -65,6 +68,7 @@ class InstagramAPI(oauth2.OAuth2API):
     delete_comment = bind_method(
                 path="/media/{media_id}/comments/{comment_id}",
                 method="DELETE",
+                signature=True,
                 accepts_parameters=['media_id', 'comment_id'],
                 response_type="empty")
 
@@ -170,6 +174,7 @@ class InstagramAPI(oauth2.OAuth2API):
     change_user_relationship = bind_method(
                 method="POST",
                 path="/users/{user_id}/relationship",
+                signature=True,
                 root_class=Relationship,
                 accepts_parameters=["user_id", "action"],
                 paginates=True,

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -24,9 +24,10 @@ class OAuth2API(object):
     # override with 'Instagram', etc
     api_name = "Generic API"
 
-    def __init__(self, client_id=None, client_secret=None, access_token=None, redirect_uri=None):
+    def __init__(self, client_id=None, client_secret=None, client_ips=None, access_token=None, redirect_uri=None):
         self.client_id = client_id
         self.client_secret = client_secret
+        self.client_ips = client_ips
         self.access_token = access_token
         self.redirect_uri = redirect_uri
 


### PR DESCRIPTION
Now we can enable the signed header by passing the `client_ips` keyword argument
to the Instagram.Client constructor.

```
c = client.InstagramAPI(
        access_token=access_token,
        client_ips="1.2.3.4",
        client_secret="CS"
    )
c.follow_user(123) # => call API with X-Insta-Forwarded-For signature.
```

If you do not set the client_ips nor client_secret, X-Insta-Forwarded-For is not sent.
