### PR TITLE
Add option for max_pages=None

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -162,7 +162,7 @@ def bind_method(**config):
         def _paginator_with_url(self, url, method="GET", body=None, headers=None):
             headers = headers or {}
             pages_read = 0
-            while url and pages_read < self.max_pages:
+            while url and (pages_read < self.max_pages or self.max_pages is None):
                 api_responses, url = self._do_api_request(url, method, body, headers)
                 pages_read += 1
                 yield api_responses, url

--- a/tests.py
+++ b/tests.py
@@ -126,6 +126,16 @@ class InstagramAPITests(unittest.TestCase):
         for page in generator:
             str(generator)
 
+    def test_generator_user_feed_all(self):
+        generator = self.api.user_media_feed(as_generator=True, max_pages=None)
+        for i in range(10):
+            page = generator.next()
+            str(generator)
+
+        generator = self.api.user_media_feed(as_generator=True, max_pages=0)
+        for page in generator:
+            assert False
+
     def test_user_liked_media(self):
         self.api.user_liked_media(count=10)
 


### PR DESCRIPTION
This allows a client to pull all user recent media. Previous [hacks](http://stackoverflow.com/a/14586216/693754) included changing `count=-1`, as in the example below,

```
feed = api.user_recent_media(user_id=user_id, count=-1, as_generator=true)

for media, next in feed:
    # do something with media
```

But on last page of results the following error would occur:

```
File "instagram/bind.py", line 106, in _build_pagination_info
return pagination.get('next_url')
AttributeError: 'NoneType' object has no attribute 'get'
```

Instead, we can supply `max_pages=None` as an argument, and achieve the desired result,

```
feed = api.user_recent_media(user_id=user_id, max_pages=None, as_generator=true)
```

Though unusual to ask for, supplying `max_pages=0` will still achieve the expected result of returning no pages.
