### PR TITLE
Create valid path if no api.format specified

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -97,7 +97,11 @@ def bind_method(**config):
                 del self.parameters[name]
 
                 self.path = self.path.replace(variable, value)
-            self.path = self.path + '.%s' % self.api.format
+
+            if self.api.format:
+                self.path = self.path + '.%s' % self.api.format
+            else:
+                self.path = self.path
 
         def _build_pagination_info(self, content_obj):
             """Extract pagination information in the desired format."""


### PR DESCRIPTION
Instagrams 

```
/media/shortcode/{shortcode}
```

endpoint does not currently respond to requests which include a requested return format, ie

```
/media/shortcode/D.json
```

and thus leave the api.media_shortcode(shortcode) permanently broken as the _build_path() will always append a trailing "."

```
/media/shortcode/D.
```

is also invalid.

Code change removes trailing "." if api.format = '' allowing the following valid request to be made

```
/media/shortcode/D
```

Is it really necessary to specify a format as instagrams own docs state [endpoint responses are returned as json](http://instagram.com/developer/endpoints/)
