### PR TITLE
drone.io CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://drone.io/github.com/cmlh/python-instagram/status.png)](https://drone.io/github.com/cmlh/python-instagram/latest)
+
 python-instagram
 ======
 A Python client for the Instagram REST and Search APIs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+bottle==0.12.7
+bottle-session==0.3
+httplib2==0.9
+python-instagram==1.1.3
+redis==2.10.3
+simplejson==3.6.3
+wsgiref==0.1.2


### PR DESCRIPTION
I integrated drone.io as a replacement to executing "python test.py" when submitting a pull request.

I omitted http://docs.drone.io/databases.html#redis as there are no unit tests for sample_app.py yet.

Also the drone.io Badge will need to be amended to reflect the git branches of https://github.com/Instagram/python-instagram rather than my forked repository.

"python tests.py" output below (yes this would be redundant if this pull request is merged):

```
..........................
----------------------------------------------------------------------
Ran 26 tests in 0.382s

OK
```

I've completed the Contributor License Agreement ("CLA") too.
