### PR TITLE
server side auth access_token_url fix

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -16,7 +16,7 @@ class OAuth2API(object):
     host = None
     base_path = None
     authorize_url = None
-    access_token_url = None
+    access_token_url = "https://api.instagram.com/oauth/access_token"
     redirect_uri = None
     # some providers use "oauth_token"
     access_token_field = "access_token"


### PR DESCRIPTION
After applying this fix, exchange_code_for_access_token method in OAuth2API object now returns the access_token.
