### PR TITLE
_do_api_request does not support 404 errors. 

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -125,6 +125,8 @@ def bind_method(**config):
             response, content = OAuth2Request(self.api).make_request(url, method=method, body=body, headers=headers)
             if response['status'] == '503' or response['status'] == '429':
                 raise InstagramAPIError(response['status'], "Rate limited", "Your client is making too many request per second")
+            elif response['status'] == '404':
+                return [], None  # No objects, and no pagination data.
             try:
                 content_obj = simplejson.loads(content.decode())
             except ValueError:


### PR DESCRIPTION
When you make an api call with wrong user id for example current _do_api_request method can't handle it. Because it's always trying to parse json data that returned from server. But in same cases like:

GET: https://api.instagram.com/v1/users/abc/

Returned response is a Http 404 page. So i made that change to stop and return empty data before trying to parse json data.