### PR TITLE
Make registered subscription callbacks tied to the reactor instance.

### DIFF
--- a/instagram/subscriptions.py
+++ b/instagram/subscriptions.py
@@ -19,7 +19,8 @@ class SubscriptionVerifyError(SubscriptionError):
 
 class SubscriptionsReactor(object):
 
-    callbacks = {}
+    def __init__(self):
+        self.callbacks = {}
 
     def _process_update(self, update):
         object_callbacks = self.callbacks.get(update['object'], [])


### PR DESCRIPTION
Hi,
I noticed that the callbacks variable of the SubscriptionsReactor is tied to the class and not to the instance and thus introduces a global state. By making the callbacks an instance variable it is easier for the user to manage callback registering code.