### PR TITLE
Fix 404 for media_shortcode because of extraneous appended format

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -53,6 +53,7 @@ def bind_method(**config):
         response_type = config.get("response_type", "list")
         include_secret = config.get("include_secret", False)
         objectify_response = config.get("objectify_response", True)
+        exclude_format = config.get('exclude_format', False)
 
         def __init__(self, api, *args, **kwargs):
             self.api = api
@@ -101,7 +102,7 @@ def bind_method(**config):
 
                 self.path = self.path.replace(variable, value)
 
-            if self.api.format:
+            if self.api.format and not self.exclude_format:
                 self.path = self.path + '.%s' % self.api.format
 
         def _build_pagination_info(self, content_obj):

--- a/instagram/client.py
+++ b/instagram/client.py
@@ -42,7 +42,8 @@ class InstagramAPI(oauth2.OAuth2API):
                 path="/media/shortcode/{shortcode}",
                 accepts_parameters=['shortcode'],
                 response_type="entry",
-                root_class=MediaShortcode)
+                root_class=MediaShortcode,
+                exclude_format=True)
 
 
     media_likes = bind_method(


### PR DESCRIPTION
Addresses #127: Add an `exclude_format` parameter to `bind_method` to allow us to build a path without the format.

This is necessary because unlike the other endpoints, `media/shortcode/{shortcode}.json` 404s
and should be requested as just `media/shortcode/{shortcode}.

## Previous behavior
```python
api = InstagramAPI(access_token=access_tken)
api.media_shortcode('os1NQjxtvF')
```
raises ```InstagramClientError: (404) Unable to parse response, not valid JSON.```


## Corrected behavior
```python
api = InstagramAPI(access_token=access_tken)
api.media_shortcode('os1NQjxtvF')
```
returns ```Media: 933107621857404944_231015329``` as expected.