### PR TITLE
python 3 compat changes

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -94,7 +94,7 @@ class OAuth2AuthExchangeRequest(object):
         return self._url_for_authorize(scope=scope)
 
     def get_authorize_login_url(self, scope=None):
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http() if six.PY3 else Http(disable_ssl_certificate_validation=True)
 
         url = self._url_for_authorize(scope=scope)
         response, content = http_object.request(url)
@@ -105,7 +105,7 @@ class OAuth2AuthExchangeRequest(object):
 
     def exchange_for_access_token(self, code=None, username=None, password=None, scope=None, user_id=None):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http() if six.PY3 else Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
         response, content = http_object.request(url, method="POST", body=data)
         parsed_content = simplejson.loads(content.decode())


### PR DESCRIPTION
This fix was introduced in line 213 for make_request() but was not present on get_authorize_login_url() exchange_for_access_token(). 
I noticed that the get_access_token.py script was breaking on python 3.4.2 for this reason, now it works. 
https://github.com/jcgregorio/httplib2/issues/173