### PR TITLE
Fixes all tests failing because of `None` secret passed to `hmac.new`

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -124,7 +124,7 @@ class OAuth2Request(object):
         sig = endpoint
         for key in sorted(params.keys()):
             sig += '|%s=%s' % (key, params[key])
-        return  hmac.new(secret, sig, sha256).hexdigest()
+        return hmac.new(secret, sig, sha256).hexdigest()
 
     def url_for_get(self, path, parameters):
         return self._full_url_with_params(path, parameters)
@@ -162,7 +162,7 @@ class OAuth2Request(object):
             return base
 
     def _signed_request(self, path, params, include_signed_request, include_secret):
-        if include_signed_request:
+        if include_signed_request and self.api.client_secret is not None:
             if self.api.access_token:
                 params['access_token'] = self.api.access_token
             elif self.api.client_id:


### PR DESCRIPTION
This change was introduced in 79c41e1a8bb3a6a2269da12ed1cebedd3a420d31 with support for signed requests.

  - All tests were previously failing with error `TypeError: object of `NoneType` has no len()`:
    https://travis-ci.org/Instagram/python-instagram/jobs/58567079
  - If we weren't given a `client_secret`, we don't have a secret to sign the request with, so `_signed_request()`
    should just return the empty string.

```
Traceback (most recent call last):
  File "tests.py", line 241, in test_change_relationship
    self.api.change_user_relationship(user_id=10, action="follow")
  File "/home/travis/build/Instagram/python-instagram/instagram/bind.py", line 196, in _call
    return method.execute()
  File "/home/travis/build/Instagram/python-instagram/instagram/bind.py", line 182, in execute
    include_secret=self.include_secret)
  File "/home/travis/build/Instagram/python-instagram/instagram/oauth2.py", line 222, in prepare_request
    url = self._full_url(path, include_secret)
  File "/home/travis/build/Instagram/python-instagram/instagram/oauth2.py", line 144, in _full_url
    self._signed_request(path, {}, include_signed_request, include_secret))
  File "/home/travis/build/Instagram/python-instagram/instagram/oauth2.py", line 172, in _signed_request
    return "&sig=%s" % self._generate_sig(path, params, self.api.client_secret)
  File "/home/travis/build/Instagram/python-instagram/instagram/oauth2.py", line 127, in _generate_sig
    return  hmac.new(secret, sig, sha256).hexdigest()
  File "/opt/python/2.6.9/lib/python2.6/hmac.py", line 133, in new
    return HMAC(key, msg, digestmod)
  File "/opt/python/2.6.9/lib/python2.6/hmac.py", line 68, in __init__
    if len(key) > blocksize:
TypeError: object of type 'NoneType' has no len()
```