### PR TITLE
Add exhaustive pagination example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,15 @@ for media in recent_media:
     photos.append('<img src="%s"/>' % media.images['thumbnail'].url)
 ```            
 
+And an example of exhaustively pursuing a paginated endpoint:
+
+``` python
+follows, next_ = api.user_follows()
+while next_:
+    more_follows, next_ = api.user_follows(with_next_url=next_)
+    follows.extend(more_follows)
+```
+
 Users: http://instagr.am/developer/endpoints/users/
     
 ``` python


### PR DESCRIPTION
I found this a bit unclear myself.  I can't find it mentioned in the provided Python wrapper docs or the official API docs themselves.  To me this feels like an important param to understand and clarify since most API results are paginated, and most people will be interested in returning multiple pages of data via the native objects (as opposed to fetching the URL with `requests` or something).