### PR TITLE
Added timeout parameter for API objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,24 @@ except InstagramAPIError as e:
       print "\nUser is set to private."
 ```
 
+Setting Timeouts
+------
+By default there is no timeout for requests to the Instagram API. You can specify a timeout in one of two ways:
+``` python
+from instagram.client import InstagramAPI
+
+# set a 30-second timeout for this particular InstagramAPI instance
+api = InstagramAPI(access_token=access_token, client_secret=client_secret, timeout=30)
+```
+or
+``` python
+import socket
+
+# Set the global default timeout, which applies to all sockets in your 
+# program where a timeout is not otherwise specified.
+socket.setdefaulttimeout(30)
+```
+
 Trouble Shooting
 ------
 

--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -94,10 +94,16 @@ def bind_method(**config):
             for variable in re_path_template.findall(self.path):
                 name = variable.strip('{}')
 
-                try:
-                    value = quote(self.parameters[name])
-                except KeyError:
-                    raise Exception('No parameter value found for path variable: %s' % name)
+                if name == 'tag_name':
+                    # XXX: tags can have unicode (non-ascii) characters, but in order
+                    # to do the signature computation correctly, we must not urlencode
+                    # them.
+                    value = self.parameters[name]
+                else:
+                    try:
+                        value = quote(self.parameters[name])
+                    except KeyError:
+                        raise Exception('No parameter value found for path variable: %s' % name)
                 del self.parameters[name]
 
                 self.path = self.path.replace(variable, value)

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -121,10 +121,13 @@ class OAuth2Request(object):
         self.api = api
 
     def _generate_sig(self, endpoint, params, secret):
-        sig = endpoint
-        for key in sorted(params.keys()):
-            sig += '|%s=%s' % (key, params[key])
-        return hmac.new(secret.encode(), sig.encode(), sha256).hexdigest()
+        # handle unicode when signing, urlencode can't handle otherwise.
+        def enc_if_str(p):
+            return p.encode('utf-8') if isinstance(p, unicode) else p
+
+        p = ''.join('|{}={}'.format(k, enc_if_str(params[k])) for k in sorted(params.keys()))
+        sig = '{}{}'.format(endpoint, p)
+        return hmac.new(secret, sig, sha256).hexdigest()
 
     def url_for_get(self, path, parameters):
         return self._full_url_with_params(path, parameters)
@@ -219,7 +222,7 @@ class OAuth2Request(object):
             if method == "POST":
                 body = self._post_body(params)
                 headers = {'Content-type': 'application/x-www-form-urlencoded'}
-                url = self._full_url(path, include_secret)
+                url = self._full_url_with_params(path, params, include_secret)
             else:
                 url = self._full_url_with_params(path, params, include_secret)
         else:

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -158,12 +158,12 @@ class OAuth2Request(object):
 
     def _auth_query(self, include_secret=False):
         if self.api.access_token:
-            return ("?%s=%s" % (self.api.access_token_field, self.api.access_token))
+            return ("?%s=%s" % (self.api.access_token_field, self.api.access_token)).encode()
         elif self.api.client_id:
             base = ("?client_id=%s" % (self.api.client_id))
             if include_secret:
                 base += "&client_secret=%s" % (self.api.client_secret)
-            return base
+            return base.encode()
 
     def _signed_request(self, path, params, include_signed_request, include_secret):
         if include_signed_request and self.api.client_secret is not None:

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -27,12 +27,13 @@ class OAuth2API(object):
     # override with 'Instagram', etc
     api_name = "Generic API"
 
-    def __init__(self, client_id=None, client_secret=None, client_ips=None, access_token=None, redirect_uri=None):
+    def __init__(self, client_id=None, client_secret=None, client_ips=None, access_token=None, redirect_uri=None, timeout=None):
         self.client_id = client_id
         self.client_secret = client_secret
         self.client_ips = client_ips
         self.access_token = access_token
         self.redirect_uri = redirect_uri
+        self.timeout = timeout
 
     def get_authorize_url(self, scope=None):
         req = OAuth2AuthExchangeRequest(self)
@@ -96,7 +97,7 @@ class OAuth2AuthExchangeRequest(object):
         return self._url_for_authorize(scope=scope)
 
     def get_authorize_login_url(self, scope=None):
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
 
         url = self._url_for_authorize(scope=scope)
         response, content = http_object.request(url)
@@ -107,7 +108,7 @@ class OAuth2AuthExchangeRequest(object):
 
     def exchange_for_access_token(self, code=None, username=None, password=None, scope=None, user_id=None):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
-        http_object = Http(disable_ssl_certificate_validation=True)
+        http_object = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
         response, content = http_object.request(url, method="POST", body=data)
         parsed_content = simplejson.loads(content.decode())
@@ -237,5 +238,8 @@ class OAuth2Request(object):
             headers.update({"User-Agent": "%s Python Client" % self.api.api_name})
         # https://github.com/jcgregorio/httplib2/issues/173
         # bug in httplib2 w/ Python 3 and disable_ssl_certificate_validation=True
-        http_obj = Http() if six.PY3 else Http(disable_ssl_certificate_validation=True)        
+        if six.PY3:
+            http_obj = Http(timeout=self.api.timeout) 
+        else:
+            http_obj = Http(timeout=self.api.timeout, disable_ssl_certificate_validation=True)
         return http_obj.request(url, method, body=body, headers=headers)

--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -124,9 +124,9 @@ class OAuth2Request(object):
     def _generate_sig(self, endpoint, params, secret):
         # handle unicode when signing, urlencode can't handle otherwise.
         def enc_if_str(p):
-            return p.encode('utf-8') if isinstance(p, unicode) else p
+            return p.encode('utf-8') if isinstance(p, basestring) else p
 
-        p = ''.join('|{}={}'.format(k, enc_if_str(params[k])) for k in sorted(params.keys()))
+        p = ''.join('|{}={}'.format(k, enc_if_str(v)) for k, v in sorted(params.items()) if k != 'sig')
         sig = '{}{}'.format(endpoint, p)
         return hmac.new(secret, sig, sha256).hexdigest()
 

--- a/python_instagram.egg-info/PKG-INFO
+++ b/python_instagram.egg-info/PKG-INFO
@@ -1,6 +1,6 @@
 Metadata-Version: 1.0
 Name: python-instagram
-Version: 1.1.3
+Version: 2.0.0
 Summary: Instagram API client
 Home-page: http://github.com/Instagram/python-instagram
 Author: Instagram, Inc

--- a/python_instagram.egg-info/requires.txt
+++ b/python_instagram.egg-info/requires.txt
@@ -1,2 +1,3 @@
 simplejson
 httplib2
+six

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bottle==0.12.7
-httplib2==0.9
+httplib2==0.10.3
 python-instagram==1.1.3
 redis==2.10.3
 simplejson==3.6.3

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 from setuptools import setup, find_packages
 
 setup(name="python-instagram",
-      version="1.3.2",
+      version="2.0.0",
       description="Instagram API client",
       license="MIT",
       install_requires=["simplejson","httplib2","six"],


### PR DESCRIPTION
By default there is no timeout on requests to the InstagramAPI. This can
cause unexpected behavior if a system is not anticipating a request to
block indefinitely.

This patch stops short of imposing a default timeout value, but does
expose the ability to specify a timeout value upon creating an api object.

The README has also been updated.
