### PR TITLE
Exceptions: added base __init__ call for proper Exception inheritance

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -20,6 +20,7 @@ class InstagramClientError(Exception):
     def __init__(self, error_message, status_code=None):
         self.status_code = status_code
         self.error_message = error_message
+        super(InstagramClientError, self).__init__(error_message, status_code)
 
     def __str__(self):
         if self.status_code:
@@ -30,10 +31,11 @@ class InstagramClientError(Exception):
 
 class InstagramAPIError(Exception):
 
-    def __init__(self, status_code, error_type, error_message, *args, **kwargs):
+    def __init__(self, status_code, error_type, error_message):
         self.status_code = status_code
         self.error_type = error_type
         self.error_message = error_message
+        super(InstagramAPIError, self).__init__(status_code, error_type, error_message)
 
     def __str__(self):
         return "(%s) %s-%s" % (self.status_code, self.error_type, self.error_message)


### PR DESCRIPTION
This is needed for proper exception handing, for example by celery (to pack/unpack exceptions .args parameter is used, and in this case it appears to be empty), but possible by other systems too.