### PR TITLE
beat > the JSON object must be str, not 'bytes'

### DIFF
--- a/instagram/bind.py
+++ b/instagram/bind.py
@@ -125,6 +125,8 @@ def bind_method(**config):
             response, content = OAuth2Request(self.api).make_request(url, method=method, body=body, headers=headers)
             if response['status'] == '503' or response['status'] == '429':
                 raise InstagramAPIError(response['status'], "Rate limited", "Your client is making too many request per second")
+            if hasattr(content, "decode"):
+                content = content.decode()
             try:
                 content_obj = simplejson.loads(content)
             except ValueError:


### PR DESCRIPTION
This was the error:
```python
  File "/hdd/ac/Dropbox/Personal/Python/insta/instagram/bind.py", line 130, in _do_api_request
    content_obj = simplejson.loads(content)
  File "/usr/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
  File "/hdd/ac/Dropbox/Personal/Python/insta/instagram/bind.py", line 130, in _do_api_request
    content_obj = simplejson.loads(content)
  File "/usr/lib/python3.4/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```