### PR TITLE
fixes #153 properly sign unicode params when making signed requests

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -121,9 +121,12 @@ class OAuth2Request(object):
         self.api = api
 
     def _generate_sig(self, endpoint, params, secret):
-        sig = endpoint
-        for key in sorted(params.keys()):
-            sig += '|%s=%s' % (key, params[key])
+        # handle unicode when signing, urlencode can't handle otherwise.
+        def enc_if_str(p):
+            return p.encode('utf-8') if isinstance(p, unicode) else p
+
+        p = ''.join('|{}={}'.format(k, enc_if_str(params[k])) for k in sorted(params.keys()))
+        sig = '{}{}'.format(endpoint, p)
         return hmac.new(secret, sig, sha256).hexdigest()
 
     def url_for_get(self, path, parameters):
@@ -219,7 +222,7 @@ class OAuth2Request(object):
             if method == "POST":
                 body = self._post_body(params)
                 headers = {'Content-type': 'application/x-www-form-urlencoded'}
-                url = self._full_url(path, include_secret)
+                url = self._full_url_with_params(path, params, include_secret)
             else:
                 url = self._full_url_with_params(path, params, include_secret)
         else:


### PR DESCRIPTION
See: https://gist.github.com/stantonk/5b0a2a2cdb9906ae038f

in master:

```
$ python prove_signed_post_request_fail.py
Traceback (most recent call last):
  File "prove_signed_post_request_fail.py", line 15, in <module>
    response = api.create_media_comment(media_id=media_id, text=u'😛 %s' % t)
  File "/Users/stantonk/Documents/code/others/python-instagram/instagram/bind.py", line 197, in _call
    return method.execute()
  File "/Users/stantonk/Documents/code/others/python-instagram/instagram/bind.py", line 189, in execute
    content, next = self._do_api_request(url, method, body, headers)
  File "/Users/stantonk/Documents/code/others/python-instagram/instagram/bind.py", line 137, in _do_api_request
    raise InstagramAPIError(content_obj.get('code'), content_obj.get('error_type'), content_obj.get('error_message'))
instagram.bind.InstagramAPIError: (403) OAuthForbiddenException-Invalid signed-request: Signature does not match
```

in my patch:

```
$ python prove_signed_post_request_fail.py
https://instagram.com/p/REDACTED/
```