### PR TITLE
Fix max_like_id  parameter in user_liked_media

### DIFF
--- a/instagram/client.py
+++ b/instagram/client.py
@@ -101,7 +101,7 @@ class InstagramAPI(oauth2.OAuth2API):
 
     user_liked_media = bind_method(
                 path="/users/self/media/liked",
-                accepts_parameters=MEDIA_ACCEPT_PARAMETERS,
+                accepts_parameters=['max_like_id','count'],
                 root_class=Media,
                 paginates=True)
 


### PR DESCRIPTION
The parameters for  GET /users/self/media/liked are access_token, count & max_like_id.
Not max_id in MEDIA_ACCEPT_PARAMETERS = ["count", "max_id"]