### PR TITLE
changing the way we check for media object field: comments to cover c…

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -94,9 +94,9 @@ class Media(ApiModel):
             for like in entry['likes']['data']:
                 new_media.likes.append(User.object_from_dictionary(like))
 
-        new_media.comment_count = entry['comments']['count']
+        new_media.comment_count = entry['comments'].get('count',0)
         new_media.comments = []
-        for comment in entry['comments']['data']:
+        for comment in entry['comments'].get('data',[]):
             new_media.comments.append(Comment.object_from_dictionary(comment))
 
         new_media.users_in_photo = []

--- a/tests.py
+++ b/tests.py
@@ -246,6 +246,20 @@ class InstagramAPITests(unittest.TestCase):
     def test_geography_recent_media(self):
         self.api.geography_recent_media(geography_id=1)
 
+    def test_media(self):
+        recent, page=self.api.user_recent_media(user_id = 10, count = 10)
+        if not page is None:
+            temp, max_id = page.split('max_id=')
+            max_id = str(max_id)
+            counter = len(recent)
+            while page and counter < max_media:
+                more_recent, page = api.user_recent_media(user_id = 10, max_id = max_id, count = max_media-counter)
+                if not page is None:
+                    temp, max_id = page.split('max_id=')
+                for med in more_recent:
+                    recent.append(med)
+                counter = len(recent)
+
 if __name__ == '__main__':
     if not TEST_AUTH:
         del InstagramAuthTests


### PR DESCRIPTION
changing the way we check for media object field: comments to cover cases where the instagram scope doesnt give back comments.data because of scope-access limitation (as sandbox mode) to have Media object still generated with other useful information instead of crushing