### PR TITLE
Fixed: issue with Requesting the access_token: You must provide a cli…

### DIFF
--- a/instagram/oauth2.py
+++ b/instagram/oauth2.py
@@ -109,7 +109,8 @@ class OAuth2AuthExchangeRequest(object):
         data = self._data_for_exchange(code, username, password, scope=scope, user_id=user_id)
         http_object = Http(disable_ssl_certificate_validation=True)
         url = self.api.access_token_url
-        response, content = http_object.request(url, method="POST", body=data)
+        headers = {'Content-type': 'application/x-www-form-urlencoded'}
+        response, content = http_object.request(url,headers=headers,method="POST", body=data)
         parsed_content = simplejson.loads(content.decode())
         if int(response['status']) != 200:
             raise OAuth2AuthExchangeError(parsed_content.get("error_message", ""))


### PR DESCRIPTION
…ent_id

Problem: It was not receiving access_token while exchanging code.
Error: You must provide a client_id

Solution:
File: oauth2.py
Function: exchange_for_access_token
        +headers = {'Content-type': 'application/x-www-form-urlencoded'}
        +response, content = http_object.request(url,headers=headers,method="POST", body=data)
-response, content = http_object.request(url,method="POST", body=data)
