### PR TITLE
fix data key

### DIFF
--- a/instagram/models.py
+++ b/instagram/models.py
@@ -96,8 +96,9 @@ class Media(ApiModel):
 
         new_media.comment_count = entry['comments']['count']
         new_media.comments = []
-        for comment in entry['comments']['data']:
-            new_media.comments.append(Comment.object_from_dictionary(comment))
+        if 'data' in entry['comments']:
+            for comment in entry['comments']['data']:
+                new_media.comments.append(Comment.object_from_dictionary(comment))
 
         new_media.users_in_photo = []
         if entry.get('users_in_photo'):


### PR DESCRIPTION
It's seems Instagram just return number of comments and do not return the detail of comments in this method that i checked! So it makes problem because there's is no key that named 'data' to append it on 'new_media.comments' 